### PR TITLE
Phase 1 simplex

### DIFF
--- a/src/simplex.jl
+++ b/src/simplex.jl
@@ -1,6 +1,6 @@
 using Printf
 
-function simplex_handler(lines::Vector{Vector{Float64}}, objective::Vector{Float64})
+function simplex_handler(lines::Vector{Vector{Float64}}, objective::Vector{Float64}; kwargs...)
     m = length(lines)
     A = zeros(m, 2)
     b = zeros(m)
@@ -9,7 +9,7 @@ function simplex_handler(lines::Vector{Vector{Float64}}, objective::Vector{Float
         A[i, 2] = lines[i][2]
         b[i]    = lines[i][3]
     end
-    return simplex_solver(A, b, objective)
+    return simplex_solver(A, b, objective; kwargs...)
 end
 
 # max c'x s.t. Ax = b, x ≥ 0

--- a/src/simplex.jl
+++ b/src/simplex.jl
@@ -184,7 +184,7 @@ end
     # so we have
     # max c'(x1 - x2) s.t. A(x1 - x2) + s = b, x1, x2, s ≥ 0
     # or 
-    # max c'x1 - c'x2 s.t. Ax1 - Ax2 + s = b, x1, x2 ≥ 0, s ≥
+    # max c'x1 - c'x2 s.t. Ax1 - Ax2 + s = b, x1, x2 ≥ 0, s ≥ 0
     # Convert to standard form
     c_std = vcat(c, -c, zeros(m))             # [ c -c 0 ]
     A_std = [A  -A Matrix{Float64}(I, m, m)]  # [ A -A I ]

--- a/src/simplex.jl
+++ b/src/simplex.jl
@@ -83,7 +83,7 @@ The initial feasible basis for this problem is `x=0, t=b`.
 function phase1_simplex(A, b, c; tol=1e-8, verbose=false, nitermax=1000)
     m, n = size(A)
 
-    # Padd constraint matrix with identity
+    # Pad constraint matrix with identity
     A_ = hcat(A, I)
     b_ = b
     c_ = vcat(zeros(n), ones(m))

--- a/src/simplex.jl
+++ b/src/simplex.jl
@@ -196,15 +196,20 @@ end
     Γ = Diagonal(γ)
     b_std = Γ * b_std  # Note: can also use lmul!(Γ, b_std)
     A_std = Γ * A_std  # Note: can also use lmul!(Γ, b_std)
+
+    Ib, iterations_phase1 = phase1_simplex(A_std, b_std, c_std; verbose=verbose)
+    # TODO: check that basis is feasible
+    basis_feasible = collect(1:(2*n+m))[Ib[1:(2*n+m)]]
     
-    iterations = revised_simplex(
+    iterations_phase2 = revised_simplex(
         c_std,
         A_std,
         b_std,
-        collect(2*n + 1 : 2*n + m);       # initial basis is all slack variables
+        basis_feasible,
         tol=tol,
         verbose=verbose
     )
+    iterations = vcat(iterations_phase1, iterations_phase2)
     iterations_original = [x[1:n] - x[n+1:2*n] for x in iterations] # x = x1 - x2
     
     return iterations_original


### PR DESCRIPTION
Added a phase 1 to the revised simplex.
* Pro: no more infeasible iterates 🥳
* Con: now it looks like the simplex goes all around the polyhedron 😅

The latter is probably due to the fact that we go from canonical form to standard, then to phase 1.
That's a lot of work / conversions that could be handled more efficiently by working with the canonical form directly.

Also note that the phase 1 is purely feasibility, i.e., it doesn't depend on the original objective.
This means that, technically, we could compute it once and re-use it as the objective varies.